### PR TITLE
@call parameter fix for zig 0.11

### DIFF
--- a/src/modules/cpus/avr5.zig
+++ b/src/modules/cpus/avr5.zig
@@ -91,7 +91,7 @@ fn make_isr_handler(comptime name: []const u8, comptime func: anytype) type {
         pub const exported_name = "microzig_isr_" ++ name;
 
         pub fn isr_vector() callconv(.Signal) void {
-            @call(.{ .modifier = .always_inline }, func, .{});
+            @call(.always_inline, func, .{});
         }
 
         comptime {


### PR DESCRIPTION
Signature of @call function changed in zig 0.11 to receive CallModifier instead of CallOptions.